### PR TITLE
configuration + user request

### DIFF
--- a/src/app/main/routes/api/user.py
+++ b/src/app/main/routes/api/user.py
@@ -26,6 +26,10 @@ def create_user():
                "true" else False, LastLogin=datetime.now(), CreatedAt=datetime.now())
     session = Device(Id=str(uuid.uuid4()), UserId=password, MacAddress=usermac,
                      ConnectedNetwork=ssid, LastConnection=datetime.now())
+
+    staticUserEmail = "central-guest@fortigate-p10.cz"
+    staticUserPassword = "ccKZ52B5HXAh"
+
     try:
         filteredUser = db.session.execute(
             db.select(User).filter_by(Email=email)).scalar_one()
@@ -35,6 +39,12 @@ def create_user():
             "password": filteredUser.Password,
             "statusCode": 200
         }
+        if Config.LOGIN_PASS:
+            returner = {
+                "username": staticUserEmail,
+                "password": staticUserPassword,
+                "statusCode": 200
+            }
         return returner
 
     except:
@@ -63,6 +73,13 @@ def create_user():
                     "statusCode": 200
                 }
 
+                if Config.LOGIN_PASS:
+                    returner = {
+                        "username": staticUserEmail,
+                        "password": staticUserPassword,
+                        "statusCode": 200
+                    }
+
                 return returner
             else:
                 returner = {
@@ -72,7 +89,7 @@ def create_user():
                 return returner
         except:
             returner = {
-                    "errorMessage": "Nepodařilo se připojit k této síti, opakujte akci později.",
-                    "statusCode": 500
-                }
+                "errorMessage": "Nepodařilo se připojit k této síti, opakujte akci později.",
+                "statusCode": 500
+            }
             return returner

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ class Config:
     API_URL = os.getenv("CAPTIVEP10_API_URL")
     DB_PATH = os.getenv("CAPTIVEP10_DB_PATH")
     LOG_PATH = os.getenv("CAPTIVEP10_LOG_PATH")
+    LOGIN_PASS = os.getenv("CAPTIVEP10_LOGIN_PASS")
 
     # FLASK CONFIGURATION
     if not ENV:


### PR DESCRIPTION
Added support in configuration for login passthrough now it is possible to set LOGIN_PASS value in env variables and the user will not be created in FG guest space instead the cental user will be used to access the Fortigate